### PR TITLE
JPA 의 연관관계 어노테이션 사용하여 User, UserLoanHistory 두 엔티티 간 관계 매핑

### DIFF
--- a/src/main/java/com/group/libraryapp/domain/user/User.java
+++ b/src/main/java/com/group/libraryapp/domain/user/User.java
@@ -1,6 +1,10 @@
 package com.group.libraryapp.domain.user;
 
+import com.group.libraryapp.domain.user.loanhistory.UserLoanHistory;
+
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "person") //매핑시킬 테이블 이름지정
@@ -12,6 +16,12 @@ public class User {
     @Column(nullable = false, length = 20, name = "name")
     private String name;
     private Integer age;
+
+    //여러 개의 UserLoanHistory 갖고있고 싶음
+    //주도권 없는 User 입장에서 mappedBy로 연관관게의 주도권 갖는 객체의 필드 이름을 명시해줘야 한다.
+    @OneToMany (mappedBy = "user") //즉, UserLoanHistory 의 user 필드를 주도궈 있는 애로 명시 - 이 값이 명시되어야 진정한 데이터 저장 가능
+    private List<UserLoanHistory> userLoanHistories = new ArrayList<>();
+
     //기본 생성자
     protected User(){}
 

--- a/src/main/java/com/group/libraryapp/domain/user/loanhistory/UserLoanHistory.java
+++ b/src/main/java/com/group/libraryapp/domain/user/loanhistory/UserLoanHistory.java
@@ -1,8 +1,7 @@
 package com.group.libraryapp.domain.user.loanhistory;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import com.group.libraryapp.domain.user.User;
+
+import javax.persistence.*;
 
 @Entity
 public class UserLoanHistory {  //DB테이블에 매핑될 객체
@@ -11,7 +10,9 @@ public class UserLoanHistory {  //DB테이블에 매핑될 객체
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private long userId;
+    //private long userId;
+    @ManyToOne //연관관계 맺게 하기
+    private User user;
 
     private String bookName;
 
@@ -22,8 +23,8 @@ public class UserLoanHistory {  //DB테이블에 매핑될 객체
     }
 
     //생성자
-    public UserLoanHistory(long userId, String bookName) {
-        this.userId = userId;
+    public UserLoanHistory(User user, String bookName) {
+        this.user = user;
         this.bookName = bookName;
         this.isReturn = false;
     }

--- a/src/main/java/com/group/libraryapp/service/book/BookService.java
+++ b/src/main/java/com/group/libraryapp/service/book/BookService.java
@@ -45,7 +45,7 @@ public class BookService {
                 .orElseThrow(IllegalArgumentException::new);
 
         //정보로 대출 기록 저장
-        userLoanHistoryRepository.save(  new UserLoanHistory(user.getId(), book.getName()));
+        userLoanHistoryRepository.save(  new UserLoanHistory(user , book.getName()));
     }
 
     //도서 반납


### PR DESCRIPTION
JPA 의 연관관계 어노테이션 사용하여 User, UserLoanHistory 두 엔티티 간 관계 매핑
@OneToMany (1:N) 관계,
@ManyToOne (N:1) 관계 설정을 해주고, 마지막으로 관계의 주도권을 누가 갖는지 두 객체에 매핑되던 테이블을 확인하여 관계 주도권이 없는 쪽에서 mappedBy 옵션으로 주도권 있는 객체의 필드 이름을 설정해주어야 진정한 데이터가 저장이 된다.
또한 이렇게 설정해줌으로써 JPA에 두 객체 간 관계가 연결되어있음을 알리는 역할을 한다.